### PR TITLE
Revert header/footer borders in minimal.css

### DIFF
--- a/docutils/docutils/writers/html5_polyglot/minimal.css
+++ b/docutils/docutils/writers/html5_polyglot/minimal.css
@@ -262,8 +262,8 @@ table.captionbelow {
 }
 
 /* Document Header and Footer */
-header { border-bottom: 1px solid black; }
-footer { border-top: 1px solid black; }
+/* header { border-bottom: 1px solid black; } */
+/* footer { border-top: 1px solid black; } */
 
 /* Images are block-level by default in Docutils */
 /* New HTML5 block elements: set display for older browsers */


### PR DESCRIPTION
These were uncommented in 32a060b5682d09eedc536bb862479b4d0d43d38e but that commit only talks about switching to html5 semantic tags, not changing the actual meaning of minimal.css

I assume this is a mistake; it interferes with the purpose of this stylesheet as a *minimal* stylesheet, and `plain.css` overrides this later anyway with `border:none`.