### PR TITLE
Fix exception when calling warn in set_class()

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,83 @@
+name: Coverage
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  with-deps:
+    name: Test with dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3"
+        cache: pip
+        cache-dependency-path: .github/workflows/coverage.yml
+
+    - name: Install dependencies
+      run: |
+        cd docutils
+        python -m pip install --upgrade pip
+        python -m pip install coverage pytest
+        python -m pip install .
+        python -m pip install pygments
+        # for recommonmark
+        python -m pip install commonmark
+        python -m pip install recommonmark --no-deps
+        # for visual inspection
+        python -m pip list
+
+    - name: Run test suite
+      run: |
+        coverage run --parallel-mode -m pytest ./docutils/test
+
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage_data
+        path: .coverage.*
+
+  coverage:
+    name: Coverage
+    needs: with-deps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3"
+          cache: pip
+          cache-dependency-path: .github/workflows/coverage.yml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install coverage
+
+      - name: Download coverage data
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage_data
+
+      - name: Combine coverage data
+        run: |
+          python -m coverage combine
+          python -m coverage report --show-missing --skip-covered
+          python -m coverage json
+          python -m coverage xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.xml
+          verbose: true

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,32 @@
+name: Lint
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  flake8:
+    name: Lint using flake8
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3
+        cache: pip
+        cache-dependency-path: .github/workflows/linting.yml
+
+    - name: Install dependencies
+      run: pip install flake8
+
+    - name: Run flake8
+      run: |
+        cd docutils
+        flake8 docutils

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,75 @@
+name: Documentation
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  render:
+    name: Publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3
+        cache: pip
+        cache-dependency-path: .github/workflows/pages.yml
+
+    - name: Install dependencies
+      run: |
+        cd docutils
+        python -m pip install --upgrade pip
+        python -m pip install -e .
+        python -m pip install pygments
+        # for recommonmark
+        python -m pip install commonmark
+        python -m pip install recommonmark --no-deps
+        # for visual inspection
+        python -m pip list
+
+    - name: Run tools/buildhtml
+      run: |
+        cd docutils
+        
+        # copy files from web/
+        cp ../web/index.txt ./index.txt
+        cp ../web/rst.txt ./rst.txt
+        cp ../web/python.png ./python.png
+        cp ../web/rst.png ./rst.png
+        
+        # convert reStructuredText source to HTML 
+        python tools/buildhtml.py --writer html5 --local .
+        python tools/buildhtml.py --writer html5 ./docs
+        
+        # Remove files under docutils/ except the CSS files
+        mkdir tmp_css
+        mv docutils/writers/html5_polyglot/* tmp_css/
+        find tmp_css/ -type f ! -name '*.css' -delete
+        rm -r docutils/
+        mkdir -p docutils/writers/html5_polyglot
+        mv tmp_css/* docutils/writers/html5_polyglot/
+        
+        # Remove other files
+        rm -r docutils.egg-info/ licenses/ test/ tools/
+        rm docutils.conf install.py MANIFEST.in setup.cfg setup.py tox.ini
+        
+        # Add files for GitHub Pages
+        touch .nojekyll
+        echo "www.docutils.org" > ./docs/CNAME
+
+    - name: Deploy to GitHub pages
+      # This allows CI to build branches for testing
+      if: github.ref == 'refs/heads/master'
+      uses: JamesIves/github-pages-deploy-action@v4.3.0
+      with:
+        branch: gh-pages
+        folder: docutils
+        single-commit: true # Delete existing files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,66 @@
+name: Test
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: Python ${{ matrix.python }}; LANG=${{ matrix.lang[0] }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+        lang:
+          # -["full lang code", "code for locale-gen"]
+          - ["C.UTF-8", "--help"]  # for the default locale we skip locale-gen
+        include:
+        - python: "3"
+          lang: ["en_GB.iso88591", "en_GB"]
+        - python: "3"
+          lang: ["de_DE.UTF-8", "de_DE.UTF-8"]
+        - python: "3"
+          lang: ["fr_FR.iso88591", "fr_FR"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python }}
+        cache: pip
+        cache-dependency-path: .github/workflows/test.yml
+
+    - name: Install dependencies
+      run: |
+        cd docutils
+        python -m pip install --upgrade pip
+        python -m pip install -e .
+        python -m pip install pytest pygments
+        # for recommonmark
+        python -m pip install commonmark
+        python -m pip install recommonmark --no-deps
+        # for visual inspection
+        python -m pip list
+
+    - name: Run test suite
+      run: |
+        cd docutils
+        sudo locale-gen ${{ matrix.lang[1] }}
+        sudo update-locale LANG=${{ matrix.lang[0] }}
+        export LANG=${{ matrix.lang[0] }}
+        export LANGUAGE=${{ matrix.lang[0] }}
+        export LC_ALL=${{ matrix.lang[0] }}
+        locale
+        python -X dev -X warn_default_encoding -m pytest ./test

--- a/docutils/docutils/nodes.py
+++ b/docutils/docutils/nodes.py
@@ -1068,7 +1068,7 @@ class Element(Node):
     def set_class(self, name):
         """Add a new class to the "classes" attribute."""
         warnings.warn('docutils.nodes.Element.set_class() is deprecated; '
-                      ' and will be removed in Docutils 0.21 or later.',
+                      ' and will be removed in Docutils 0.21 or later. '
                       "Append to Element['classes'] list attribute directly",
                       DeprecationWarning, stacklevel=2)
         assert ' ' not in name


### PR DESCRIPTION
This fixes a wrong syntax when calling the `warn()` function. 

Probably a stray comma was inserted here by accident, which messes up the syntax. 

It fixes the following Exception for me:
```
Exception occurred:
  File "C:\Users\mel\mambaforge\envs\sphinx2\Lib\site-packages\docutils\nodes.py", line 1069, in set_class
    warnings.warn('docutils.nodes.Element.set_class() is deprecated; '
TypeError: argument for warn() given by name ('stacklevel') and position (3)
```