### PR TITLE
GHA CI workflows: Update actions versions, enable Python 3.13, remove Python 3.7 and 3.8

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,96 @@
+name: Coverage
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: "1"
+  PYTHONDEVMODE: "1"  # -X dev
+  PYTHONWARNDEFAULTENCODING: "1"  # -X warn_default_encoding
+  PYTHONWARNINGS: "error"  # -W error
+
+jobs:
+  with-deps:
+    name: Test with dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3"
+        cache: pip
+        cache-dependency-path: .github/workflows/coverage.yml
+
+    - name: Install dependencies
+      run: |
+        cd docutils
+        python -m pip install --upgrade pip
+        python -m pip install coverage pytest
+        python -m pip install .
+        python -m pip install "pygments<=2.13"
+        # for recommonmark
+        python -m pip install commonmark
+        python -m pip install recommonmark --no-deps
+        # for visual inspection
+        python -m pip list
+      env:
+        PYTHONWARNINGS: ""
+
+    - name: Run test suite
+      run: |
+        coverage run --parallel-mode -m pytest ./docutils/test -vv
+
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage_data
+        path: .coverage.*
+
+  coverage:
+    name: Coverage
+    needs: with-deps
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3"
+        cache: pip
+        cache-dependency-path: .github/workflows/coverage.yml
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install coverage
+      env:
+        PYTHONWARNINGS: ""
+
+    - name: Download coverage data
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage_data
+
+    - name: Combine coverage data
+      run: |
+        python -m coverage combine
+        python -m coverage report --show-missing --skip-covered
+        python -m coverage json
+        python -m coverage xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./coverage.xml
+        verbose: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3"
         cache: pip
@@ -52,7 +52,7 @@ jobs:
         coverage run --parallel-mode -m pytest ./docutils/test -vv
 
     - name: Upload coverage data
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage_data
         path: .coverage.*
@@ -62,9 +62,9 @@ jobs:
     needs: with-deps
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3"
         cache: pip
@@ -78,7 +78,7 @@ jobs:
         PYTHONWARNINGS: ""
 
     - name: Download coverage data
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: coverage_data
 
@@ -90,7 +90,7 @@ jobs:
         python -m coverage xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         files: ./coverage.xml
         verbose: true

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,35 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  flake8:
+    name: Lint using flake8
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3
+        cache: pip
+        cache-dependency-path: .github/workflows/linting.yml
+
+    - name: Install dependencies
+      run: pip install "flake8<6"
+
+    - name: Run flake8
+      run: |
+        cd docutils
+        flake8 docutils

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3
         cache: pip

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3
         cache: pip

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,92 @@
+name: Documentation
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  render:
+    name: Render
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3
+        cache: pip
+        cache-dependency-path: .github/workflows/pages.yml
+
+    - name: Install dependencies
+      run: |
+        cd docutils
+        python -m pip install --upgrade pip
+        python -m pip install -e .
+        python -m pip install pygments
+        # for recommonmark
+        python -m pip install commonmark
+        python -m pip install recommonmark --no-deps
+        # for visual inspection
+        python -m pip list
+
+    - name: Run tools/buildhtml
+      run: |
+        cd docutils
+        
+        # copy files from web/
+        cp ../web/index.txt ./index.txt
+        cp ../web/rst.txt ./rst.txt
+        cp ../web/python.png ./python.png
+        cp ../web/rst.png ./rst.png
+        
+        # convert reStructuredText source to HTML 
+        python tools/buildhtml.py --writer html5 --local .
+        python tools/buildhtml.py --writer html5 ./docs
+        
+        # Remove files under docutils/ except the CSS files
+        mkdir tmp_css
+        mv docutils/writers/html5_polyglot/* tmp_css/
+        find tmp_css/ -type f ! -name '*.css' -delete
+        rm -r docutils/
+        mkdir -p docutils/writers/html5_polyglot
+        mv tmp_css/* docutils/writers/html5_polyglot/
+        
+        # Remove other files
+        rm -r licenses/ test/ tools/
+        rm docutils.conf tox.ini
+        
+        # Add files for GitHub Pages
+        touch .nojekyll
+        echo "www.docutils.org" > ./docs/CNAME
+
+    - name: Upload the generated HTML as a GitHub Actions artefact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: docutils
+
+  publish:
+    name: Publish
+    needs: "render"
+    # This allows CI to build branches for testing
+    if: github.repository_owner == 'docutils' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+
+    permissions:
+      # This allows publishing to the GitHub Pages site.
+      pages: write
+      # This allows GitHub Pages to verify that the deployment comes
+      # from a legitimate source through OpenID Connect.
+      id-token: write
+
+    steps:
+    - name: Deploy to GitHub pages
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,8 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12-dev"
+          - "3.12"
+          - "3.13"
         lang:
           # -["full lang code", "code for locale-gen"]
           - ["C.UTF-8", "--help"]  # for the default locale we skip locale-gen
@@ -49,6 +50,7 @@ jobs:
         python-version: ${{ matrix.python }}
         cache: pip
         cache-dependency-path: .github/workflows/test.yml
+        allow-prereleases: true
       env:
         PYTHONWARNINGS: ""
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,9 +44,9 @@ jobs:
           lang: ["fr_FR.iso88591", "fr_FR"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
         cache: pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,149 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: "1"
+  PYTHONDEVMODE: "1"  # -X dev
+  PYTHONWARNDEFAULTENCODING: "1"  # -X warn_default_encoding
+  PYTHONWARNINGS: "error"  # -W error
+
+jobs:
+  tests:
+    name: Python ${{ matrix.python }}; LANG=${{ matrix.lang[0] }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12-dev"
+        lang:
+          # -["full lang code", "code for locale-gen"]
+          - ["C.UTF-8", "--help"]  # for the default locale we skip locale-gen
+        include:
+        - python: "3"
+          lang: ["en_GB.iso88591", "en_GB"]
+        - python: "3"
+          lang: ["de_DE.UTF-8", "de_DE.UTF-8"]
+        - python: "3"
+          lang: ["fr_FR.iso88591", "fr_FR"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python }}
+        cache: pip
+        cache-dependency-path: .github/workflows/test.yml
+      env:
+        PYTHONWARNINGS: ""
+
+    - name: Install dependencies
+      run: |
+        cd docutils
+        python -m pip install --upgrade pip
+        python -m pip install .
+        python -m pip install pytest pytest-subtests pygments
+        # for recommonmark
+        python -m pip install commonmark
+        python -m pip install recommonmark --no-deps
+        # for visual inspection
+        python -m pip list
+      env:
+        PYTHONWARNINGS: ""
+
+    - name: Generate locale
+      if: matrix.lang[0] != 'C.UTF-8'
+      run: |
+        sudo locale-gen ${{ matrix.lang[1] }}
+        sudo update-locale LANG=${{ matrix.lang[0] }}
+        export LANG=${{ matrix.lang[0] }}
+        export LANGUAGE=${{ matrix.lang[0] }}
+        export LC_ALL=${{ matrix.lang[0] }}
+        locale
+
+    - name: Run test suite (pytest ./test)
+      if: always()
+      env:
+        LANG: ${{ matrix.lang[0] }}
+        LANGUAGE: ${{ matrix.lang[0] }}
+        LC_ALL: ${{ matrix.lang[0] }}
+      run: |
+        cd docutils
+        python -m pytest -vv ./test
+
+    - name: Run test suite (pytest .)
+      if: always()
+      env:
+        LANG: ${{ matrix.lang[0] }}
+        LANGUAGE: ${{ matrix.lang[0] }}
+        LC_ALL: ${{ matrix.lang[0] }}
+      run: |
+        cd docutils
+        python -m pytest -vv .
+
+    - name: Run test suite (pytest . in ./test)
+      if: always()
+      env:
+        LANG: ${{ matrix.lang[0] }}
+        LANGUAGE: ${{ matrix.lang[0] }}
+        LC_ALL: ${{ matrix.lang[0] }}
+      run: |
+        cd docutils/test
+        python -m pytest -vv .
+
+    - name: Run test suite (python -m unittest discover -v)
+      if: always()      
+      env:
+          LANG: ${{ matrix.lang[0] }}
+          LANGUAGE: ${{ matrix.lang[0] }}
+          LC_ALL: ${{ matrix.lang[0] }}
+      run: |
+          cd docutils
+          python -m unittest discover -v
+
+    - name: Run test suite (python -m unittest discover -v in ./test)
+      if: always()      
+      env:
+          LANG: ${{ matrix.lang[0] }}
+          LANGUAGE: ${{ matrix.lang[0] }}
+          LC_ALL: ${{ matrix.lang[0] }}
+      run: |
+          cd docutils/test
+          python -m unittest discover -v
+
+    - name: Run test suite (alltests.py)
+      if: always()      
+      env:
+          LANG: ${{ matrix.lang[0] }}
+          LANGUAGE: ${{ matrix.lang[0] }}
+          LC_ALL: ${{ matrix.lang[0] }}
+      run: |
+          cd docutils
+          python test/alltests.py
+
+    - name: Run test suite (alltests.py in ./test)
+      if: always()      
+      env:
+          LANG: ${{ matrix.lang[0] }}
+          LANGUAGE: ${{ matrix.lang[0] }}
+          LC_ALL: ${{ matrix.lang[0] }}
+      run: |
+          cd docutils/test
+          python alltests.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.7"
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/docutils/pyproject.toml
+++ b/docutils/pyproject.toml
@@ -43,6 +43,8 @@ classifiers = [
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Documentation',
         'Topic :: Software Development :: Documentation',
         'Topic :: Text Processing',

--- a/docutils/tox.ini
+++ b/docutils/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-envlist = py{39,310,311,312}
+envlist = py{39,310,311,312,313}
 
 [testenv]
 allowlist_externals =


### PR DESCRIPTION
- Python 3.7 and 3.8 removed because docutils requires python>=3.9
- Enable Python 3.13 in the CI worklows (via actions/setup-python's [allow-prerelease](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#allow-pre-releases)) and in tox.ini
- Updated actions to their lastest version

FWIW, tests are failing with:

```python
==================================== ERRORS ====================================
_____________ ERROR collecting test/extra/test_math_conversion.py ______________
test/extra/test_math_conversion.py:73: in <module>
    html = publish_file(source_path=str(source_path),
docutils/core.py:422: in publish_file
    output, publisher = publish_programmatically(
docutils/core.py:720: in publish_programmatically
    publisher.set_source(source, source_path)
docutils/core.py:189: in set_source
    self.source = self.source_class(
docutils/io.py:381: in __init__
    self.source = open(source_path, mode,
E   EncodingWarning: 'encoding' argument not specified
_______________________ ERROR collecting test/test_io.py _______________________
test/test_io.py:31: in <module>
    locale.getpreferredencoding(do_setlocale=False)).name
/opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/locale.py:673: in getpreferredencoding
    warnings.warn(
E   EncodingWarning: UTF-8 Mode affects locale.getpreferredencoding(). Consider locale.getencoding() instead.
=========================== short test summary info ============================
ERROR test/extra/test_math_conversion.py - EncodingWarning: 'encoding' argument not specified
ERROR test/test_io.py - EncodingWarning: UTF-8 Mode affects locale.getpreferredencoding(). Consider locale.getencoding() instead.
!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!
============================== 2 errors in 1.13s ===============================
```