### PR TITLE
fix: guard DependencyList.close() against None file attribute

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,103 @@
+name: Coverage
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: "1"
+  UV_SYSTEM_PYTHON: "1"  # make uv do global installs
+  PYTHONDEVMODE: "1"  # -X dev
+  PYTHONWARNDEFAULTENCODING: "1"  # -X warn_default_encoding
+  PYTHONWARNINGS: "error"  # -W error
+
+jobs:
+  with-deps:
+    name: Test with dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python 3
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: latest
+        enable-cache: false
+
+    - name: Install dependencies
+      run: |
+        cd docutils
+        uv pip install coverage pytest
+        uv pip install .
+        uv pip install pygments
+        # for recommonmark
+        uv pip install commonmark
+        uv pip install recommonmark --no-deps
+        # for visual inspection
+        python -m pip list
+      env:
+        PYTHONWARNINGS: ""
+
+    - name: Run test suite
+      run: coverage run --parallel-mode -m pytest ./docutils/test -vv
+
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        include-hidden-files: true
+        name: coverage_data
+        path: .coverage.*
+
+  coverage:
+    name: Coverage
+    needs: with-deps
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python 3
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: latest
+        enable-cache: false
+
+    - name: Install dependencies
+      run: uv pip install coverage
+      env:
+        PYTHONWARNINGS: ""
+
+    - name: Download coverage data
+      uses: actions/download-artifact@v7
+      with:
+        name: coverage_data
+
+    - name: Combine coverage data
+      run: |
+        python -m coverage combine
+        python -m coverage report --show-missing --skip-covered
+        python -m coverage json
+        python -m coverage xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        files: ./coverage.xml
+        verbose: true

--- a/.github/workflows/fetch-svn.yml
+++ b/.github/workflows/fetch-svn.yml
@@ -1,0 +1,39 @@
+name: Fetch from SVN
+
+on:
+  schedule:
+  - cron: "9/15 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: "1"
+  UV_SYSTEM_PYTHON: "1"  # make uv do global installs
+
+jobs:
+  fetch:
+    if: github.repository_owner == 'docutils'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        persist-credentials: true
+
+    - name: Configure git
+      run: |
+        git config user.name "Adam Turner"
+        git config user.email "9087854+aa-turner@users.noreply.github.com"
+
+    - name: Fetch from Docutils upstream
+      run: |
+        git remote add upstream https://repo.or.cz/docutils.git
+        git fetch --all --progress --prune
+        git rebase upstream/master
+        git push origin master --force-with-lease || true

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,81 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: "1"
+  UV_SYSTEM_PYTHON: "1"  # make uv do global installs
+
+jobs:
+  ruff:
+    name: Lint using Ruff
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3"
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: latest
+        enable-cache: false
+    - name: Install Ruff
+      run: uv pip install "ruff==0.9.10"
+    - name: Lint with Ruff
+      run: ruff check docutils --output-format github
+
+  flake8:
+    name: Lint using flake8
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3"
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: latest
+        enable-cache: false
+    - name: Install flake8
+      run: uv pip install flake8
+    - name: Run flake8
+      run: flake8 docutils
+
+  twine:
+    name: Check packaging using twine
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3"
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: latest
+        enable-cache: false
+    - name: Install dependencies
+      run: uv pip install twine build
+    - name: Lint with twine
+      run: |
+        cd docutils
+        python -m build
+        twine check --strict dist/*

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,99 @@
+name: Documentation
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: "1"
+  UV_SYSTEM_PYTHON: "1"  # make uv do global installs
+
+jobs:
+  render:
+    name: Render
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python 3
+      uses: actions/setup-python@v6
+      with:
+        python-version: 3
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: latest
+        enable-cache: false
+
+    - name: Install dependencies
+      run: |
+        cd docutils
+        uv pip install .
+        uv pip install pygments
+        # for recommonmark
+        uv pip install commonmark
+        uv pip install recommonmark --no-deps
+        # for visual inspection
+        python -m pip list
+
+    - name: Run tools/buildhtml
+      run: |
+        cd docutils
+
+        # copy files from web/
+        cp ../web/index.rst ./index.rst
+        cp ../web/rst.rst ./rst.rst
+        cp ../web/python.png ./python.png
+        cp ../web/rst.png ./rst.png
+
+        # convert reStructuredText source to HTML
+        python tools/buildhtml.py --writer html5 --local .
+        python tools/buildhtml.py --writer html5 ./docs
+
+        # Remove files under docutils/ except the CSS files
+        mkdir tmp_css
+        mv docutils/writers/html5_polyglot/* tmp_css/
+        find tmp_css/ -type f ! -name '*.css' -delete
+        rm -r docutils/
+        mkdir -p docutils/writers/html5_polyglot
+        mv tmp_css/* docutils/writers/html5_polyglot/
+
+        # Remove other files
+        rm -r licenses/ test/ tools/
+        rm docutils.conf tox.ini
+
+        # Add files for GitHub Pages
+        touch .nojekyll
+        echo "www.docutils.org" > ./docs/CNAME
+
+    - name: Upload the generated HTML as a GitHub Actions artefact
+      uses: actions/upload-pages-artifact@v4
+      with:
+        path: docutils
+
+  publish:
+    name: Publish
+    needs: "render"
+    # This allows CI to build branches for testing
+    if: github.repository_owner == 'docutils' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+
+    permissions:
+      # This allows publishing to the GitHub Pages site.
+      pages: write
+      # This allows GitHub Pages to verify that the deployment comes
+      # from a legitimate source through OpenID Connect.
+      id-token: write
+
+    steps:
+    - name: Deploy to GitHub pages
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,284 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: "1"
+  UV_SYSTEM_PYTHON: "1"  # make uv do global installs
+  PYTHONDEVMODE: "1"  # -X dev
+  PYTHONWARNDEFAULTENCODING: "1"  # -X warn_default_encoding
+  PYTHONWARNINGS: "error"  # -W error
+
+jobs:
+  ubuntu:
+    name: "Ubuntu: Python ${{ matrix.python }}; LANG=${{ matrix.lang[0] }}; PYTHONUTF8=${{ matrix.utf-8-mode }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # TODO Test with Pillow
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+          - "3.15-dev"
+        utf-8-mode:
+          - ""
+        lang:
+          # -["full lang code", "code for locale-gen"]
+          - ["C.UTF-8", "--help"]  # for the default locale we skip locale-gen
+        include:
+        - python: "3"
+          lang: ["en_GB.iso88591", "en_GB"]
+          utf-8-mode: ""
+        - python: "3"
+          lang: ["de_DE.UTF-8", "de_DE.UTF-8"]
+          utf-8-mode: ""
+        - python: "3"
+          lang: ["fr_FR.iso88591", "fr_FR"]
+          utf-8-mode: ""
+
+        # https://docs.python.org/dev/library/os.html#utf8-mode
+        - python: "3"
+          lang: ["C.UTF-8", "--help"]
+          utf-8-mode: "1"
+        - python: "3"
+          lang: ["en_GB.iso88591", "en_GB"]
+          utf-8-mode: "1"
+        - python: "3"
+          lang: ["de_DE.UTF-8", "de_DE.UTF-8"]
+          utf-8-mode: "1"
+        - python: "3"
+          lang: ["fr_FR.iso88591", "fr_FR"]
+          utf-8-mode: "1"
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python }}
+      env:
+        PYTHONWARNINGS: ""
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: latest
+        enable-cache: false
+
+    - name: Install dependencies
+      run: |
+        cd docutils
+        uv pip install .
+        uv pip install pytest pytest-subtests pygments
+        # for recommonmark
+        uv pip install commonmark
+        uv pip install recommonmark --no-deps
+        # for visual inspection
+        python -m pip list
+      env:
+        PYTHONWARNINGS: ""
+
+    - name: Generate locale
+      if: matrix.lang[0] != 'C.UTF-8'
+      run: |
+        sudo locale-gen ${{ matrix.lang[1] }}
+        sudo update-locale LANG=${{ matrix.lang[0] }}
+        export LANG=${{ matrix.lang[0] }}
+        export LANGUAGE=${{ matrix.lang[0] }}
+        export LC_ALL=${{ matrix.lang[0] }}
+        locale
+
+    - name: Run test suite (pytest ./test)
+      if: always()
+      env:
+        LANG: ${{ matrix.lang[0] }}
+        LANGUAGE: ${{ matrix.lang[0] }}
+        LC_ALL: ${{ matrix.lang[0] }}
+        PYTHONUTF8: ${{ matrix.utf-8-mode }}
+      run: |
+        cd docutils
+        python -m pytest -vv ./test
+
+    - name: Run test suite (pytest .)
+      if: always()
+      env:
+        LANG: ${{ matrix.lang[0] }}
+        LANGUAGE: ${{ matrix.lang[0] }}
+        LC_ALL: ${{ matrix.lang[0] }}
+        PYTHONUTF8: ${{ matrix.utf-8-mode }}
+      run: |
+        cd docutils
+        python -m pytest -vv .
+
+    - name: Run test suite (pytest . in ./test)
+      if: always()
+      env:
+        LANG: ${{ matrix.lang[0] }}
+        LANGUAGE: ${{ matrix.lang[0] }}
+        LC_ALL: ${{ matrix.lang[0] }}
+        PYTHONUTF8: ${{ matrix.utf-8-mode }}
+      run: |
+        cd docutils/test
+        python -m pytest -vv .
+
+    - name: Run test suite (python -m unittest discover -v)
+      if: always()
+      env:
+        LANG: ${{ matrix.lang[0] }}
+        LANGUAGE: ${{ matrix.lang[0] }}
+        LC_ALL: ${{ matrix.lang[0] }}
+        PYTHONUTF8: ${{ matrix.utf-8-mode }}
+      run: |
+        cd docutils
+        python -m unittest discover -v
+
+    - name: Run test suite (python -m unittest discover -v in ./test)
+      if: always()
+      env:
+        LANG: ${{ matrix.lang[0] }}
+        LANGUAGE: ${{ matrix.lang[0] }}
+        LC_ALL: ${{ matrix.lang[0] }}
+        PYTHONUTF8: ${{ matrix.utf-8-mode }}
+      run: |
+        cd docutils/test
+        python -m unittest discover -v
+
+    - name: Run test suite (alltests.py)
+      if: always()
+      env:
+        LANG: ${{ matrix.lang[0] }}
+        LANGUAGE: ${{ matrix.lang[0] }}
+        LC_ALL: ${{ matrix.lang[0] }}
+        PYTHONUTF8: ${{ matrix.utf-8-mode }}
+      run: |
+        cd docutils
+        python test/alltests.py
+
+    - name: Run test suite (alltests.py in ./test)
+      if: always()
+      env:
+        LANG: ${{ matrix.lang[0] }}
+        LANGUAGE: ${{ matrix.lang[0] }}
+        LC_ALL: ${{ matrix.lang[0] }}
+        PYTHONUTF8: ${{ matrix.utf-8-mode }}
+      run: |
+        cd docutils/test
+        python alltests.py
+
+  windows:
+    name: "Windows: Python ${{ matrix.python }}; PYTHONUTF8=${{ matrix.utf-8-mode }}"
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+          - "3.15-dev"
+        utf-8-mode:
+          - ""
+        include:
+        # https://docs.python.org/dev/library/os.html#utf8-mode
+        - python: "3"
+          utf-8-mode: "1"
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python }}
+      env:
+        PYTHONWARNINGS: ""
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: latest
+        enable-cache: false
+
+    - name: Install dependencies
+      run: |
+        cd docutils
+        uv pip install .
+        uv pip install pytest pytest-subtests pygments
+        # for recommonmark
+        uv pip install commonmark
+        uv pip install recommonmark --no-deps
+        # for visual inspection
+        python -m pip list
+      env:
+        PYTHONWARNINGS: ""
+
+    - name: Run test suite (pytest ./test)
+      if: always()
+      run: |
+        cd docutils
+        python -m pytest -vv ./test
+      env:
+        PYTHONUTF8: ${{ matrix.utf-8-mode }}
+
+    - name: Run test suite (pytest .)
+      if: always()
+      run: |
+        cd docutils
+        python -m pytest -vv .
+      env:
+        PYTHONUTF8: ${{ matrix.utf-8-mode }}
+
+    - name: Run test suite (pytest . in ./test)
+      if: always()
+      run: |
+        cd docutils/test
+        python -m pytest -vv .
+      env:
+        PYTHONUTF8: ${{ matrix.utf-8-mode }}
+
+    - name: Run test suite (python -m unittest discover -v)
+      if: always()
+      run: |
+        cd docutils
+        python -m unittest discover -v
+      env:
+        PYTHONUTF8: ${{ matrix.utf-8-mode }}
+
+    - name: Run test suite (python -m unittest discover -v in ./test)
+      if: always()
+      run: |
+        cd docutils/test
+        python -m unittest discover -v
+      env:
+        PYTHONUTF8: ${{ matrix.utf-8-mode }}
+
+    - name: Run test suite (alltests.py)
+      if: always()
+      run: |
+        cd docutils
+        python test/alltests.py
+      env:
+        PYTHONUTF8: ${{ matrix.utf-8-mode }}
+
+    - name: Run test suite (alltests.py in ./test)
+      if: always()
+      run: |
+        cd docutils/test
+        python alltests.py
+      env:
+        PYTHONUTF8: ${{ matrix.utf-8-mode }}

--- a/docutils/docutils/utils/__init__.py
+++ b/docutils/docutils/utils/__init__.py
@@ -838,7 +838,7 @@ class DependencyList:
         """
         Close the output file.
         """
-        if self.file is not sys.stdout:
+        if self.file is not None and self.file is not sys.stdout:
             self.file.close()
         self.file = None
 


### PR DESCRIPTION
Closes #13

```python
# Before: crashes with AttributeError
dl = DependencyList()
dl.close()  # AttributeError: 'NoneType' object has no attribute 'close'

# After: works correctly  
dl = DependencyList()
dl.close()  # no-op, safe to call multiple times
```

When `self.file` is `None` (from `output_file=None`/empty string, or after a prior `close()`), the condition `self.file is not sys.stdout` evaluates to `True` since `None is not sys.stdout`, leading to `None.close()`.

Adds a `None` guard so `close()` is safe to call unconditionally.